### PR TITLE
Update to 1.3

### DIFF
--- a/Source/PaletteWindow.cs
+++ b/Source/PaletteWindow.cs
@@ -215,6 +215,7 @@ namespace CommandPalette
             var pos         = canvas.min;
             var fadeColor   = new Color( 1f, 1f, 1f, 1 - fade );
             var designators = query.NullOrEmpty() ? VisibleRecentlyUsed : FilteredDesignators;
+            GizmoRenderParms parms = new GizmoRenderParms();
             foreach ( var designator in designators )
             {
                 // add 10 px of wiggle room for rounding errors
@@ -230,7 +231,7 @@ namespace CommandPalette
                 var iconColor = designator.defaultIconColor;
                 designator.defaultIconColor = fadeColor;
                 GUI.color                   = fadeColor;
-                var result = designator.GizmoOnGUI( pos, GIZMO_SIZE );
+                var result = designator.GizmoOnGUI( pos, GIZMO_SIZE, parms );
                 designator.defaultIconColor =  iconColor;
                 pos.x                       += GIZMO_SIZE + MARGIN;
                 switch ( result.State )


### PR DESCRIPTION
GizmoOnGUI now takes a structure GizmoRenderParms with three boolean values offering extra features (highLight, lowLight, shrunk).  None of these are needed, so create an empty GizmoRenderParms object which is equal to all three being false and pass it into the GizmoOnGUI function.

Other than that, point to the latest version of Harmony, put the old "Assemblies" folder into a new folder called "1.2" and output the new one to "1.3\Assemblies" and you're good to go.  This is the only breaking change in the code that I could find.

I did have to turn off the mod update -x command line build option, but I assume that's something specific to your environment to clean up or something.